### PR TITLE
Allow UTF-8 letters in username, fixes #24

### DIFF
--- a/app/models/Data.scala
+++ b/app/models/Data.scala
@@ -467,7 +467,7 @@ object Player {
       if (name.length > 64) {
         Left("Name must be less than 65 characters")
       }
-      else if ("[^a-zA-Z0-9\\s]".r.findFirstIn(name).isDefined) {
+      else if ("[^\\p{L}0-9\\s]".r.findFirstIn(name).isDefined) {
         Left("Name must only contain letters, numbers, and spaces")
       }
       else if (profanity.matches(name)) {

--- a/test/models/DataSpec.scala
+++ b/test/models/DataSpec.scala
@@ -221,6 +221,18 @@ class DataSpec extends AnyWordSpec with Matchers with EitherValues with BeforeAn
 
       result must equal (Right(Player(service.get.toString, name.get, new URL("https://avatars.githubusercontent.com/GoogleCloudPlatform"))))
     }
+    "pass for non-US username" in {
+      val names = List(Some("Zażółć gęślą jaźń"), Some("Příliš žluťoučký kůň úpěl ďábelské ódy"), Some("Ζαφείρι δέξου πάγκαλο βαθῶν ψυχῆς τὸ σῆμα"))
+      val githubUser = Some("GoogleCloudPlatform")
+      val service = Some(new URL("https://zxcv.com"))
+      val fetchPlayers = Future.successful(Set.empty[Player])
+      def validateGithubUser(url: String) = Future.successful(None)
+      def validateService(url: URL) = Future.successful(None)
+
+      val results = names.map { name => await(Player.validate(name, service, githubUser)(neverProfane, avatarBase)(fetchPlayers)(validateGithubUser)(validateService)) }
+
+      names.lazyZip(results).foreach { (name, result) => result must equal (Right(Player(service.get.toString, name.get, new URL("https://avatars.githubusercontent.com/GoogleCloudPlatform")))) }
+    }
     "fail when the name is invalid" in {
       val githubUser = Some("GoogleCloudPlatform")
       val service = Some(new URL("https://zxcv.com"))


### PR DESCRIPTION
- changed the regex used in username validation to allow letters from any language/alphabet, still disallowing non-letter characters. 
- test cases use three pangrams from Polish, Czech and Greek